### PR TITLE
Fix ping#170 for no more rhx_gis

### DIFF
--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -309,11 +309,8 @@ class Client(object):
 
     @staticmethod
     def _extract_rhx_gis(html):
-        mobj = re.search(
-            r'"rhx_gis":"(?P<rhx_gis>[a-f0-9]{32})"', html, re.MULTILINE)
-        if mobj:
-            return mobj.group('rhx_gis')
-        return None
+        tmp_str = ':{"id":"'+f'{random.randint(10000000,99999999)}'+'"}'
+        return hashlib.md5(tmp_str.encode()).hexdigest()
 
     @staticmethod
     def _extract_csrftoken(html):


### PR DESCRIPTION
For to no longer require the rhx_gis key in the response

Why was this PR needed?

Current code was breaking when this key was removed from the Instagram response

What are the relevant issue numbers?

#170