### PR TITLE
Allow media_likers endpoint without login

### DIFF
--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -591,7 +591,7 @@ class Client(object):
             return [c['node'] for c in info.get('data', {}).get('shortcode_media', {}).get(
                 'edge_media_to_comment', {}).get('edges', [])]
         return info
-   
+
     def media_likers(self, short_code, **kwargs):
         """
         Get media likers

--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -591,8 +591,7 @@ class Client(object):
             return [c['node'] for c in info.get('data', {}).get('shortcode_media', {}).get(
                 'edge_media_to_comment', {}).get('edges', [])]
         return info
-
-    @login_required
+   
     def media_likers(self, short_code, **kwargs):
         """
         Get media likers

--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -307,13 +307,18 @@ class Client(object):
             media_id = media_id.split('_')[0]
         return media_id
 
+    # @staticmethod
+    # def _extract_rhx_gis(html):
+    #     mobj = re.search(
+    #         r'"rhx_gis":"(?P<rhx_gis>[a-f0-9]{32})"', html, re.MULTILINE)
+    #     if mobj:
+    #         return mobj.group('rhx_gis')
+    #     return None
+
     @staticmethod
     def _extract_rhx_gis(html):
-        mobj = re.search(
-            r'"rhx_gis":"(?P<rhx_gis>[a-f0-9]{32})"', html, re.MULTILINE)
-        if mobj:
-            return mobj.group('rhx_gis')
-        return None
+        tmp_str = ':{"id":"'+f'{random.randint(10000000,99999999)}'+'"}'
+        return hashlib.md5(b'tmp_str')
 
     @staticmethod
     def _extract_csrftoken(html):


### PR DESCRIPTION
enables the media_likers endpoint without needing to login

(Briefly describe what this PR is about.)

Users don't need to be logged in in order to access media_likers

(Briefly describe reasons.)

No issues raised yet

(List issue numbers here.)